### PR TITLE
function argument typo in `test_CuInsAsmRepos.py`

### DIFF
--- a/Tests/test_CuInsAsmRepos.py
+++ b/Tests/test_CuInsAsmRepos.py
@@ -6,10 +6,10 @@ from CuAsm.CuInsFeeder import CuInsFeeder
 
 def constructReposFromFile(sassname, savname=None, arch='sm_75'):
     # initialize a feeder with sass
-    feeder = CuInsFeeder(sassname, arch=arch)
+    feeder = CuInsFeeder(sassname, archfilter=arch)
 
     # initialize an empty repos
-    repos = CuInsAssemblerRepos(arch=arch)#
+    repos = CuInsAssemblerRepos(archfilter=arch)#
 
     # Update the repos with instructions from feeder
     repos.update(feeder)
@@ -29,10 +29,10 @@ def constructReposFromFile(sassname, savname=None, arch='sm_75'):
 def verifyReposFromFile(sassname, reposfile, arch='sm_75'):
 
     # initialize a feeder with sass
-    feeder = CuInsFeeder(sassname, arch=arch)
+    feeder = CuInsFeeder(sassname, archfilter=arch)
 
     # initialize an empty repos
-    repos = CuInsAssemblerRepos(reposfile, arch=arch)#
+    repos = CuInsAssemblerRepos(reposfile, archfilter=arch)#
 
     # verify the repos
     repos.verify(feeder)

--- a/Tests/test_CuInsAsmRepos.py
+++ b/Tests/test_CuInsAsmRepos.py
@@ -9,7 +9,7 @@ def constructReposFromFile(sassname, savname=None, arch='sm_75'):
     feeder = CuInsFeeder(sassname, archfilter=arch)
 
     # initialize an empty repos
-    repos = CuInsAssemblerRepos(archfilter=arch)#
+    repos = CuInsAssemblerRepos(arch=arch)#
 
     # Update the repos with instructions from feeder
     repos.update(feeder)
@@ -32,7 +32,7 @@ def verifyReposFromFile(sassname, reposfile, arch='sm_75'):
     feeder = CuInsFeeder(sassname, archfilter=arch)
 
     # initialize an empty repos
-    repos = CuInsAssemblerRepos(reposfile, archfilter=arch)#
+    repos = CuInsAssemblerRepos(reposfile, arch=arch)#
 
     # verify the repos
     repos.verify(feeder)

--- a/Tests/test_CuInsAsmRepos_sm50.py
+++ b/Tests/test_CuInsAsmRepos_sm50.py
@@ -6,10 +6,10 @@ from CuAsm.CuInsFeeder import CuInsFeeder
 
 def constructReposFromFile(sassname, savname=None, arch='sm_75'):
     # initialize a feeder with sass
-    feeder = CuInsFeeder(sassname, arch=arch)
+    feeder = CuInsFeeder(sassname, archfilter=arch)
 
     # initialize an empty repos
-    repos = CuInsAssemblerRepos(arch=arch)#
+    repos = CuInsAssemblerRepos(archfilter=arch)#
 
     # Update the repos with instructions from feeder
     repos.update(feeder)
@@ -29,10 +29,10 @@ def constructReposFromFile(sassname, savname=None, arch='sm_75'):
 def verifyReposFromFile(sassname, reposfile, arch='sm_75'):
 
     # initialize a feeder with sass
-    feeder = CuInsFeeder(sassname, arch=arch)
+    feeder = CuInsFeeder(sassname, archfilter=arch)
 
     # initialize an empty repos
-    repos = CuInsAssemblerRepos(reposfile, arch=arch)#
+    repos = CuInsAssemblerRepos(reposfile, archfilter=arch)#
 
     # verify the repos
     repos.verify(feeder)

--- a/Tests/test_CuInsAsmRepos_sm50.py
+++ b/Tests/test_CuInsAsmRepos_sm50.py
@@ -9,7 +9,7 @@ def constructReposFromFile(sassname, savname=None, arch='sm_75'):
     feeder = CuInsFeeder(sassname, archfilter=arch)
 
     # initialize an empty repos
-    repos = CuInsAssemblerRepos(archfilter=arch)#
+    repos = CuInsAssemblerRepos(arch=arch)#
 
     # Update the repos with instructions from feeder
     repos.update(feeder)
@@ -32,7 +32,7 @@ def verifyReposFromFile(sassname, reposfile, arch='sm_75'):
     feeder = CuInsFeeder(sassname, archfilter=arch)
 
     # initialize an empty repos
-    repos = CuInsAssemblerRepos(reposfile, archfilter=arch)#
+    repos = CuInsAssemblerRepos(reposfile, arch=arch)#
 
     # verify the repos
     repos.verify(feeder)


### PR DESCRIPTION
The argument of class `CuInsFeeder` is archfilter. `feeder = CuInsFeeder(sassname, arch=arch)` leads to error.